### PR TITLE
issue with wrong codes being revealed

### DIFF
--- a/commands/decRound.js
+++ b/commands/decRound.js
@@ -3,10 +3,10 @@ module.exports = {
     "name": "decround",
     "onlyGame": "decrypto",
     "execute": (msg, args, table) => {
-        let messages = table.game.startRound();
         for (let i = 0; i < 2; i++) {
             msg.channel.send(table.game.revealCode(i));
         }
+        let messages = table.game.startRound();
         if(typeof(messages) == 'string'){
             msg.reply(messages);
             return;


### PR DESCRIPTION
in decRound command the round was started before the codes were revealed so it was revealing the codes for the new round instead of the intended functionality of revealing the codes from the round that just passed